### PR TITLE
Pushflags

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,30 @@ $ cf install-plugin $GOPATH/bin/autopilot
 ## usage
 
 ```
-$ cf zero-downtime-push application-to-replace \
-    -f path/to/new_manifest.yml \
-    -p path/to/new/path
+$ cf zero-downtime-push APP [-b URL] [-c COMMAND] [-d DOMAIN] [-f MANIFEST] / 
+[-i NUM_INSTANCES] [-m MEMORY] [-n HOST] [-p PATH] [-s STACK] / 
+[--no-hostname] [--no-route] [--no-start]
 ```
+
+Optional arguments include:
+
+- -b — Custom buildpack URL, for example, https://github.com/heroku/heroku-buildpack-play.git or https://github.com/heroku/heroku-buildpack-play.git#stable to select stable branch
+- -c — Start command for the application.
+- -d — Domain, for example, example.com.
+- -f — replaces --manifest
+- -i — Number of instances of the application to run.
+- -m — Memory limit, for example, 256, 1G, 1024M, and so on.
+- -n — Hostname, for example, my-subdomain.
+- -p — Path to application directory or archive.
+- -s — Stack to use.
+- -t — Timeout to start in seconds.
+- --no-hostname — Map the root domain to this application (NEW).
+- --no-manifest — Ignore manifests if they exist.
+- --no-route — Do not map a route to this application (NEW).
+- --no-start — Do not start the application after pushing.
+
+Note: The `–no-route` option also removes existing routes from previous pushes of this app.
+
 
 ## method
 
@@ -40,3 +60,7 @@ delivery environments.
    now goes to the new application.
 
 [indiana-jones]: https://www.youtube.com/watch?v=0gU35Tgtlmg
+
+## tests
+
+Tests are run by calling the script *test.sh* in the *scripts* directory. You may need to modify the GOROOT and GOPATH in the script to reflect the proper paths in your environment.

--- a/autopilot.go
+++ b/autopilot.go
@@ -34,9 +34,13 @@ func (plugin AutopilotPlugin) Run(cliConnection plugin.CliConnection, args []str
 	if err != nil {
 		fmt.Fprintln(os.Stdout, "error:", err)
 		err = appRepo.DeleteApplication(appName)
-		fatalIf(err)
+		if err != nil {
+			fmt.Fprintln(os.Stdout, "error:", err)
+		}
 		err := appRepo.RenameApplication(venerableAppName, appName)
-		fatalIf(err)
+		if err != nil {
+			fmt.Fprintln(os.Stdout, "error:", err)
+		}
 		os.Exit(1)
 	}
 

--- a/autopilot_test.go
+++ b/autopilot_test.go
@@ -48,41 +48,36 @@ var _ = Describe("ApplicationRepo", func() {
 
 	Describe("PushApplication", func() {
 		It("pushes an application with both a manifest and a path", func() {
-			err := repo.PushApplication("-f /path/to/a/manifest.yml -p /path/to/the/app")
+			err := repo.PushApplication([]string{"-f /path/to/a/manifest.yml -p /path/to/the/app"})
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(cliConn.CliCommandCallCount()).Should(Equal(1))
 			args := cliConn.CliCommandArgsForCall(0)
-			Ω(args).Should(Equal([]string{
-				"push",
-				"-f", "/path/to/a/manifest.yml",
-				"-p", "/path/to/the/app",
-			}))
+			Ω(args).Should(Equal([]string{"push", "-f /path/to/a/manifest.yml -p /path/to/the/app"}))
 		})
 
 		It("pushes an application with only a manifest", func() {
-			err := repo.PushApplication("-f /path/to/a/manifest.yml")
+			err := repo.PushApplication([]string{"-f /path/to/a/manifest.yml"})
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(cliConn.CliCommandCallCount()).Should(Equal(1))
 			args := cliConn.CliCommandArgsForCall(0)
-			Ω(args).Should(Equal([]string{
-				"push",
-				"-f", "/path/to/a/manifest.yml",
-			}))
+			Ω(args).Should(Equal([]string{"push", "-f /path/to/a/manifest.yml"}))
 		})
 
 		It("pushes an application with no manifest or path", func() {
-			err := repo.PushApplication("")
-			Ω(err).Should(MatchError(ErrNoManifest))
+			err := repo.PushApplication([]string{""})
+			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(cliConn.CliCommandCallCount()).Should(Equal(1))
+			args := cliConn.CliCommandArgsForCall(0)
+			Ω(args).Should(Equal([]string{"push", ""}))
 		})
 
 		It("returns errors from the push", func() {
 			cliConn.CliCommandReturns([]string{}, errors.New("bad app"))
 
-			err := repo.PushApplication("/path/to/a/manifest.yml", "/path/to/the/app")
+			err := repo.PushApplication([]string{"-f /path/to/a/manifest.yml -p /path/to/the/app"})
 			Ω(err).Should(MatchError("bad app"))
 		})
 	})

--- a/autopilot_test.go
+++ b/autopilot_test.go
@@ -48,7 +48,7 @@ var _ = Describe("ApplicationRepo", func() {
 
 	Describe("PushApplication", func() {
 		It("pushes an application with both a manifest and a path", func() {
-			err := repo.PushApplication("/path/to/a/manifest.yml", "/path/to/the/app")
+			err := repo.PushApplication("-f /path/to/a/manifest.yml -p /path/to/the/app")
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(cliConn.CliCommandCallCount()).Should(Equal(1))
@@ -61,7 +61,7 @@ var _ = Describe("ApplicationRepo", func() {
 		})
 
 		It("pushes an application with only a manifest", func() {
-			err := repo.PushApplication("/path/to/a/manifest.yml", "")
+			err := repo.PushApplication("-f /path/to/a/manifest.yml")
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(cliConn.CliCommandCallCount()).Should(Equal(1))
@@ -72,18 +72,11 @@ var _ = Describe("ApplicationRepo", func() {
 			}))
 		})
 
-		It("does not push an application with just a path", func() {
-			err := repo.PushApplication("", "/path/to/the/app")
+		It("pushes an application with no manifest or path", func() {
+			err := repo.PushApplication("")
 			Ω(err).Should(MatchError(ErrNoManifest))
 
-			Ω(cliConn.CliCommandCallCount()).Should(Equal(0))
-		})
-
-		It("does not push an application with no manifest or path", func() {
-			err := repo.PushApplication("", "/path/to/the/app")
-			Ω(err).Should(MatchError(ErrNoManifest))
-
-			Ω(cliConn.CliCommandCallCount()).Should(Equal(0))
+			Ω(cliConn.CliCommandCallCount()).Should(Equal(1))
 		})
 
 		It("returns errors from the push", func() {


### PR DESCRIPTION
I've updated the code to pass all arguments to the PushApplication function. I figure there is no need for this plug in to deal with push flags and to just leverage the error catching system. This is so zero-downtime-push will have the same usage as push.

I've also updated the code so if a push fails, it will try to delete <app> and rename the <app>-venerable back to <app>. (I think this can be implemented a lot better than how I did it...) 

 Something unexpected: If I just call `cf zero-downtime-push` it will return no result. I was try to code it so it gave back the usage information or even just try to do a push => similar to just doing a `cf push`. But was not able to get this working.