### PR TITLE
adding usage details to help output

### DIFF
--- a/autopilot.go
+++ b/autopilot.go
@@ -77,6 +77,9 @@ func (AutopilotPlugin) GetMetadata() plugin.PluginMetadata {
 			{
 				Name:     "zero-downtime-push",
 				HelpText: "Perform a zero-downtime push of an application over the top of an old one",
+				UsageDetails: plugin.Usage { 
+					Usage: "$ cf zero-downtime-push application-to-replace \\ \n \t-f path/to/new_manifest.yml \\ \n \t-p path/to/new/path",
+        },
 			},
 		},
 	}


### PR DESCRIPTION
it really bothered me that the help for autopilot (zero-downtime-push) didn't include usage details. i had to go to the autopilot readme on github to look it up each time.