### PR TITLE
Only push named app.

### DIFF
--- a/autopilot.go
+++ b/autopilot.go
@@ -40,7 +40,7 @@ func getActionsForExistingApp(appRepo *ApplicationRepo, appName, manifestPath, a
 		// push
 		{
 			Forward: func() error {
-				return appRepo.PushApplication(manifestPath, appPath)
+				return appRepo.PushApplication(appName, manifestPath, appPath)
 			},
 			ReversePrevious: func() error {
 				// If the app cannot start we'll have a lingering application
@@ -59,12 +59,12 @@ func getActionsForExistingApp(appRepo *ApplicationRepo, appName, manifestPath, a
 	}
 }
 
-func getActionsForNewApp(appRepo *ApplicationRepo, manifestPath, appPath string) []rewind.Action {
+func getActionsForNewApp(appRepo *ApplicationRepo, appName, manifestPath, appPath string) []rewind.Action {
 	return []rewind.Action{
 		// push
 		{
 			Forward: func() error {
-				return appRepo.PushApplication(manifestPath, appPath)
+				return appRepo.PushApplication(appName, manifestPath, appPath)
 			},
 		},
 	}
@@ -83,7 +83,7 @@ func (plugin AutopilotPlugin) Run(cliConnection plugin.CliConnection, args []str
 	if appExists {
 		actionList = getActionsForExistingApp(appRepo, appName, manifestPath, appPath)
 	} else {
-		actionList = getActionsForNewApp(appRepo, manifestPath, appPath)
+		actionList = getActionsForNewApp(appRepo, appName, manifestPath, appPath)
 	}
 
 	actions := rewind.Actions{
@@ -158,8 +158,8 @@ func (repo *ApplicationRepo) RenameApplication(oldName, newName string) error {
 	return err
 }
 
-func (repo *ApplicationRepo) PushApplication(manifestPath, appPath string) error {
-	args := []string{"push", "-f", manifestPath}
+func (repo *ApplicationRepo) PushApplication(appName, manifestPath, appPath string) error {
+	args := []string{"push", appName, "-f", manifestPath}
 
 	if appPath != "" {
 		args = append(args, "-p", appPath)

--- a/autopilot_test.go
+++ b/autopilot_test.go
@@ -160,26 +160,28 @@ var _ = Describe("ApplicationRepo", func() {
 
 	Describe("PushApplication", func() {
 		It("pushes an application with both a manifest and a path", func() {
-			err := repo.PushApplication("/path/to/a/manifest.yml", "/path/to/the/app")
+			err := repo.PushApplication("appName", "/path/to/a/manifest.yml", "/path/to/the/app")
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(cliConn.CliCommandCallCount()).To(Equal(1))
 			args := cliConn.CliCommandArgsForCall(0)
 			Expect(args).To(Equal([]string{
 				"push",
+				"appName",
 				"-f", "/path/to/a/manifest.yml",
 				"-p", "/path/to/the/app",
 			}))
 		})
 
 		It("pushes an application with only a manifest", func() {
-			err := repo.PushApplication("/path/to/a/manifest.yml", "")
+			err := repo.PushApplication("appName", "/path/to/a/manifest.yml", "")
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(cliConn.CliCommandCallCount()).To(Equal(1))
 			args := cliConn.CliCommandArgsForCall(0)
 			Expect(args).To(Equal([]string{
 				"push",
+				"appName",
 				"-f", "/path/to/a/manifest.yml",
 			}))
 		})
@@ -187,7 +189,7 @@ var _ = Describe("ApplicationRepo", func() {
 		It("returns errors from the push", func() {
 			cliConn.CliCommandReturns([]string{}, errors.New("bad app"))
 
-			err := repo.PushApplication("/path/to/a/manifest.yml", "/path/to/the/app")
+			err := repo.PushApplication("appName", "/path/to/a/manifest.yml", "/path/to/the/app")
 			Expect(err).To(MatchError("bad app"))
 		})
 	})


### PR DESCRIPTION
Avoid downtime on multi-application manifests. See #23 for details.

[Resolves #23]